### PR TITLE
drivers: add gpio driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-# AstraRTOS - Makefile for stm32f429zi
-
 PREFIX = arm-none-eabi-
 CC = $(PREFIX)gcc
 AS = $(PREFIX)gcc -x assembler-with-cpp
@@ -11,7 +9,7 @@ SIZE = $(PREFIX)size 	   # prints table with sizes
 TARGET = astra
 BUILD = build
 
-C_SOURCES = app/main.c kernel/port/system_init.c drivers/src/rcc.c drivers/src/uart.c
+C_SOURCES = app/main.c kernel/port/system_init.c drivers/src/rcc.c drivers/src/uart.c drivers/src/gpio.c
 AS_SOURCES = kernel/port/startup_stm32f429zi.s 
 
 LDSCRIPT = link/stm32f429zi.ld 

--- a/drivers/include/gpio.h
+++ b/drivers/include/gpio.h
@@ -1,8 +1,31 @@
 #ifndef GPIO_H
 #define GPIO_H
 
+#include <stdint.h>
+
 #define GPIOA_BASE 0x40020000
-#define GPIOA_MODER (*(volatile uint32_t*)(GPIOA_BASE + 0x00))
-#define GPIOA_AFRL (*(volatile uint32_t*)(GPIOA_BASE + 0x20))
+#define GPIOB_BASE 0x40020400
+#define GPIOC_BASE 0x40020800
+#define GPIOD_BASE 0x40020C00
+#define GPIOE_BASE 0x40021000
+#define GPIOF_BASE 0x40021400
+#define GPIOG_BASE 0x40021800
+#define GPIOH_BASE 0x40021C00
+
+#define GPIO_MODER(base) (*(volatile uint32_t*)((base) + 0x00))
+#define GPIO_IDR(base) (*(volatile uint32_t*)((base) + 0x10))
+#define GPIO_ODR(base) (*(volatile uint32_t*)((base) + 0x14))
+#define GPIO_BSRR(base) (*(volatile uint32_t*)((base) + 0x18))
+#define GPIO_AFRL(base) (*(volatile uint32_t*)((base) + 0x20))
+
+#define GPIO_MODE_INPUT 0
+#define GPIO_MODE_OUTPUT 1
+#define GPIO_MODE_AF 2
+#define GPIO_MODE_ANALOG 3
+
+void gpio_set_mode(uint32_t base, uint32_t pin, uint32_t mode);
+void gpio_toggle(uint32_t base, uint32_t pin);
+void gpio_write(uint32_t base, uint32_t pin, uint32_t value);
+uint32_t gpio_read(uint32_t base, uint32_t pin);
 
 #endif

--- a/drivers/src/gpio.c
+++ b/drivers/src/gpio.c
@@ -1,0 +1,24 @@
+#include "gpio.h"
+
+void gpio_set_mode(uint32_t base, uint32_t pin, uint32_t mode){
+    int pin_offset = pin*2;
+    GPIO_MODER(base) &= ~(3 << pin_offset);
+    GPIO_MODER(base) |= (mode << pin_offset);
+}
+
+void gpio_toggle(uint32_t base, uint32_t pin){
+    GPIO_ODR(base) ^= (1 << pin); 
+
+}
+
+void gpio_write(uint32_t base, uint32_t pin, uint32_t value){
+    if(value == 1){
+        GPIO_BSRR(base) = (1 << pin);   // set
+    }else{
+        GPIO_BSRR(base) = (1 << (pin + 16));    // reset    
+    }
+}
+
+uint32_t gpio_read(uint32_t base, uint32_t pin){    
+    return ((GPIO_IDR(base)) >> pin) & 1;
+}

--- a/drivers/src/uart.c
+++ b/drivers/src/uart.c
@@ -8,11 +8,11 @@ void uart_init(void){
     rcc_enable_gpio(GPIOA_EN);
     rcc_enable_uart(USART2_EN);
 
-    GPIOA_MODER &= ~((3 << (2*2)) | (3 << (3*2))); //Clear Pins 2 and 3
-    GPIOA_MODER |= ((2 << (2*2)) | (2 << (3*2))); //Sets to AF mode
+    GPIO_MODER(GPIOA_BASE) &= ~((3 << (2*2)) | (3 << (3*2))); //Clear Pins 2 and 3
+    GPIO_MODER(GPIOA_BASE) |= ((2 << (2*2)) | (2 << (3*2))); //Sets to AF mode
 
-    GPIOA_AFRL &= ~((0xF << (2*4)) | (0xF << (3*4))); //Clear 
-    GPIOA_AFRL |= ((7 << (2*4)) | (7 << (3*4))); //Selecting AF to USART2
+    GPIO_AFRL(GPIOA_BASE) &= ~((0xF << (2*4)) | (0xF << (3*4))); //Clear 
+    GPIO_AFRL(GPIOA_BASE) |= ((7 << (2*4)) | (7 << (3*4))); //Selecting AF to USART2
 
     USART2_BRR = 0x1250; //9600 BaudRate (Condition: Peripheral Clock (APB1) = 45MHz)
 


### PR DESCRIPTION
add gpio driver with gpio function calls - `gpio_set_mode`, `gpio_write`, `gpio_read`, `gpio_toggle`
and modify gpio header file to pass base address macros to cover all ports   