### PR TITLE
kernel: add recursive depth to mutex implementation

### DIFF
--- a/kernel/include/mutex.h
+++ b/kernel/include/mutex.h
@@ -5,6 +5,7 @@
 typedef struct{
     int is_locked;
     int task_num_owner;
+    int recursive_depth;
 } os_mutex_t;
 
 void os_mutex_init(os_mutex_t *mutex);

--- a/kernel/src/mutex.c
+++ b/kernel/src/mutex.c
@@ -8,6 +8,7 @@ extern uint32_t os_get_task_count();
 void os_mutex_init(os_mutex_t *mutex){
     mutex->is_locked = 0;
     mutex->task_num_owner = -1;
+    mutex->recursive_depth = 0;
 }
 void os_mutex_take(os_mutex_t *mutex){
     while(1){
@@ -15,6 +16,12 @@ void os_mutex_take(os_mutex_t *mutex){
         if(mutex->is_locked == 0){
             mutex->is_locked = 1;
             mutex->task_num_owner = os_current_task_ptr->task_num;
+            mutex->recursive_depth = 1;
+            __asm volatile ("cpsie i");
+            break;
+        }
+        else if(mutex->is_locked == 1 && mutex->task_num_owner == os_current_task_ptr->task_num){
+            mutex->recursive_depth ++;
             __asm volatile ("cpsie i");
             break;
         }
@@ -29,6 +36,11 @@ void os_mutex_take(os_mutex_t *mutex){
 void os_mutex_give(os_mutex_t *mutex){
     __asm volatile ("cpsid i");
     if(mutex->task_num_owner == os_current_task_ptr->task_num){
+        mutex->recursive_depth --;
+        if(mutex->recursive_depth > 0){
+            __asm volatile ("cpsie i");
+            return;
+        }
         mutex->is_locked = 0;
         mutex->task_num_owner = -1;
         for(uint32_t i = 0; i < os_get_task_count() ; i++){


### PR DESCRIPTION
adds a recursive depth count to prevent deadlocks if a helper function inside a task takes mutex already owned by the task 