### PR TITLE
kernel: fix task array storage and pointer inconsistency

### DIFF
--- a/kernel/include/task.h
+++ b/kernel/include/task.h
@@ -1,17 +1,13 @@
 #ifndef H_TASK
 #define H_TASK
-
 #include <stdint.h>
-
 #define OS_MAX_TASKS_NUM 20
-
 typedef enum {
     TASK_READY,
     TASK_BLOCKED,
     TASK_MUTEX_WAITING,
     TASK_SEM_WAITING
 }os_task_state;
-
 typedef struct {
     uint32_t *stack_ptr;
     int task_num;
@@ -21,14 +17,11 @@ typedef struct {
     uint32_t priority;
     uint32_t base_priority;
 }os_tcb_t;
-
+extern os_tcb_t *os_tasks[];
+extern os_tcb_t *os_current_task_ptr;
 void os_delay(uint32_t t);
 void os_decrement_blocked_tasks(void);
-
-extern os_tcb_t *os_current_task_ptr;
 extern void os_schedule_next_task(void);
-
 int os_task_create(void (*task_fucntion)(void), uint32_t priority, uint32_t stack_size);
 void os_start(void);
-
 #endif

--- a/kernel/src/mutex.c
+++ b/kernel/src/mutex.c
@@ -1,10 +1,7 @@
 #include "mutex.h"
 #include "task.h"
 #define ICSR (*((volatile uint32_t *)0xE000ED04))
-extern os_tcb_t os_tasks[];
-extern os_tcb_t *os_current_task_ptr;
 extern uint32_t os_get_task_count();
-
 void os_mutex_init(os_mutex_t *mutex){
     mutex->is_locked = 0;
     mutex->task_num_owner = -1;
@@ -26,9 +23,9 @@ void os_mutex_take(os_mutex_t *mutex){
             break;
         }
         else{
-            os_tcb_t *owner = &os_tasks[mutex->task_num_owner];
+            os_tcb_t *owner = os_tasks[mutex->task_num_owner];
             if(os_current_task_ptr->priority > owner->priority){
-                owner->priority = os_current_task_ptr->priority; 
+                owner->priority = os_current_task_ptr->priority;
             }
             os_current_task_ptr->state = TASK_MUTEX_WAITING;
             os_current_task_ptr->waiting_for_resource = (void *)mutex;
@@ -49,31 +46,31 @@ void os_mutex_give(os_mutex_t *mutex){
         mutex->task_num_owner = -1;
         uint32_t new_priority = os_current_task_ptr->base_priority;
         for(uint32_t i = 0; i < os_get_task_count(); i++){
-            if(os_tasks[i].state == TASK_MUTEX_WAITING){
-                os_mutex_t* temp_mutex = (void *)os_tasks[i].waiting_for_resource;
+            if(os_tasks[i]->state == TASK_MUTEX_WAITING){
+                os_mutex_t *temp_mutex = (void *)os_tasks[i]->waiting_for_resource;
                 if(temp_mutex->task_num_owner == os_current_task_ptr->task_num){
-                    if(os_tasks[i].priority > new_priority){
-                        new_priority = os_tasks[i].priority;
+                    if(os_tasks[i]->priority > new_priority){
+                        new_priority = os_tasks[i]->priority;
                     }
                 }
             }
         }
         os_current_task_ptr->priority = new_priority;
-        uint32_t best_priority  = 0;
+        uint32_t best_priority = 0;
         int chosen_index = -1;
-        for(uint32_t i = 0; i < os_get_task_count() ; i++){
-            if(os_tasks[i].state == TASK_MUTEX_WAITING){
-                if(os_tasks[i].waiting_for_resource == (void *)mutex){
-                    if(chosen_index == -1 || (os_tasks[i].priority > best_priority)){
-                        best_priority = os_tasks[i].priority;
+        for(uint32_t i = 0; i < os_get_task_count(); i++){
+            if(os_tasks[i]->state == TASK_MUTEX_WAITING){
+                if(os_tasks[i]->waiting_for_resource == (void *)mutex){
+                    if(chosen_index == -1 || (os_tasks[i]->priority > best_priority)){
+                        best_priority = os_tasks[i]->priority;
                         chosen_index = i;
                     }
                 }
             }
         }
         if(chosen_index != -1){
-            os_tasks[chosen_index].state = TASK_READY;
-            os_tasks[chosen_index].waiting_for_resource = 0;
+            os_tasks[chosen_index]->state = TASK_READY;
+            os_tasks[chosen_index]->waiting_for_resource = 0;
         }
     }
     __asm volatile ("cpsie i");

--- a/kernel/src/sem.c
+++ b/kernel/src/sem.c
@@ -1,15 +1,11 @@
 #include "sem.h"
 #include "task.h"
 #define ICSR (*((volatile uint32_t *)0xE000ED04))
-extern os_tcb_t os_tasks[];
-extern os_tcb_t *os_current_task_ptr;
 extern uint32_t os_get_task_count();
-
 void os_sem_init(os_sem_t *sem, int initial_count, int max_count){
     sem->count = initial_count;
     sem->max_count = max_count;
 }
-
 void os_sem_take(os_sem_t *sem){
     while(1){
         __asm volatile ("cpsid i");
@@ -24,29 +20,26 @@ void os_sem_take(os_sem_t *sem){
             __asm volatile ("cpsie i");
             ICSR |= (1 << 28);
         }
-
-
     }
 }
-
 void os_sem_give(os_sem_t *sem){
     __asm volatile ("cpsid i");
     if(sem->count < sem->max_count){
         sem->count++;
     }
-    uint32_t best_priority  = 0;
+    uint32_t best_priority = 0;
     int chosen_index = -1;
-    for(uint32_t i =0; i < os_get_task_count(); i++){
-        if(os_tasks[i].state == TASK_SEM_WAITING && os_tasks[i].waiting_for_resource == sem){
-            if(chosen_index == -1 || (os_tasks[i].priority > best_priority)){
-                best_priority = os_tasks[i].priority;
+    for(uint32_t i = 0; i < os_get_task_count(); i++){
+        if(os_tasks[i]->state == TASK_SEM_WAITING && os_tasks[i]->waiting_for_resource == sem){
+            if(chosen_index == -1 || (os_tasks[i]->priority > best_priority)){
+                best_priority = os_tasks[i]->priority;
                 chosen_index = i;
             }
         }
     }
     if(chosen_index != -1){
-        os_tasks[chosen_index].state = TASK_READY;
-        os_tasks[chosen_index].waiting_for_resource = 0;
-    }    
+        os_tasks[chosen_index]->state = TASK_READY;
+        os_tasks[chosen_index]->waiting_for_resource = 0;
+    }
     __asm volatile ("cpsie i");
 }

--- a/kernel/src/task.c
+++ b/kernel/src/task.c
@@ -2,12 +2,9 @@
 #include "heap.h"
 #define SHPR3 (*(volatile uint8_t *)0xE000ED22)  /*sets PendSV priority*/
 #define ICSR (*((volatile uint32_t *)0xE000ED04))
-
 os_tcb_t *os_tasks[OS_MAX_TASKS_NUM];
 os_tcb_t *os_current_task_ptr = 0;
-
 static uint32_t os_task_count = 0;
-
 int os_task_create(void (*task_function)(void), uint32_t priority , uint32_t stack_size){
     if(os_task_count >= OS_MAX_TASKS_NUM){
         return -1;
@@ -22,28 +19,25 @@ int os_task_create(void (*task_function)(void), uint32_t priority , uint32_t sta
         return -1;
     }
     uint32_t *task_stack_ptr = &task_stack[stack_size - 1];
-
     *task_stack_ptr = 0x01000000;
     task_stack_ptr -= 1;
     *task_stack_ptr = (uint32_t)task_function;
     task_stack_ptr -= 1;
     *task_stack_ptr = 0xFFFFFFFD;
     task_stack_ptr -= 13;
-
     task->stack_ptr = task_stack_ptr;
     task->task_num = os_task_count;
     task->state = TASK_READY;
     task->delay_ticks = 0;
     task->priority = priority;
     task->base_priority = priority;
-
     if(os_task_count == 0){
         os_current_task_ptr = task;
     }
+    os_tasks[os_task_count] = task;
     os_task_count += 1;
     return 0;
 }
-
 void os_delay(uint32_t ticks){
     __asm volatile ("cpsid i");
     os_current_task_ptr->delay_ticks = ticks;
@@ -51,7 +45,6 @@ void os_delay(uint32_t ticks){
     __asm volatile ("cpsie i");
     ICSR |= (1 << 28);
 }
-
 void os_decrement_blocked_tasks(void){
     for(uint32_t i = 0; i < os_task_count; i++){
         if(os_tasks[i]->state == TASK_BLOCKED && os_tasks[i]->delay_ticks > 0){
@@ -62,8 +55,6 @@ void os_decrement_blocked_tasks(void){
         }
     }
 }
-
-
 void os_schedule_next_task(void){
     uint32_t best_priority  = -1;
     int chosen_index = -1;
@@ -83,19 +74,16 @@ void os_schedule_next_task(void){
         }
     }
 }
-
 static void os_idle_task(void){
     while(1){
         __asm volatile ("wfi"); // CPU sleep 
     }
 }
-
 void os_start(void) {
     os_task_create(os_idle_task, 0, 64);   // default to sleep
     SHPR3 = 255;              /*sets PendSV to lowest priority*/
     __asm volatile ("svc 0"); /*triggers SVC*/
 }
-
 uint32_t os_get_task_count(){
     return os_task_count;
 }


### PR DESCRIPTION
Store task pointer in os_tasks[] on creation in os_task_create(). Update mutex and sem to use os_tcb_t pointer array consistently.

Fixes #24 