### PR TITLE
app: add mutex-based sample

### DIFF
--- a/samples/mutex_basic/README.md
+++ b/samples/mutex_basic/README.md
@@ -1,0 +1,21 @@
+## Mutex sample code
+
+Two tasks (`task1` and `task2`) increment and print a shared counter
+over UART, protected by a mutex.
+
+`task1` runs every 500 ms, `task2` runs every 700 ms. Both run at
+priority 2 with a stack size of 128.
+
+The mutex (`os_mutex_init`, `os_mutex_take`, `os_mutex_give`) ensures
+that incrementing the counter and printing its value happens
+atomically — preventing the two tasks from interleaving and producing
+inconsistent output or a corrupted counter value.
+
+### Expected output (over UART1)
+```
+Task1: counter = 1
+Task2: counter = 2
+Task1: counter = 3
+Task2: counter = 4
+...
+```

--- a/samples/mutex_basic/README.md
+++ b/samples/mutex_basic/README.md
@@ -1,21 +1,9 @@
 ## Mutex sample code
+Two tasks increment and print a shared counter, protected by a mutex.
 
-Two tasks (`task1` and `task2`) increment and print a shared counter
-over UART, protected by a mutex.
+Task 1 increments and prints the counter every 500 ms,task 2 every 700 ms.
+The mutex (os_mutex_init, os_mutex_take, os_mutex_give) ensures only
+one task accesses the counter at a time, preventing race conditions
+and interleaved output.
 
-`task1` runs every 500 ms, `task2` runs every 700 ms. Both run at
-priority 2 with a stack size of 128.
-
-The mutex (`os_mutex_init`, `os_mutex_take`, `os_mutex_give`) ensures
-that incrementing the counter and printing its value happens
-atomically — preventing the two tasks from interleaving and producing
-inconsistent output or a corrupted counter value.
-
-### Expected output (over UART1)
-```
-Task1: counter = 1
-Task2: counter = 2
-Task1: counter = 3
-Task2: counter = 4
-...
-```
+Both tasks run at priority 2 with a stack size of 128.

--- a/samples/mutex_basic/main.c
+++ b/samples/mutex_basic/main.c
@@ -1,0 +1,79 @@
+#include "system_init.h"
+#include "uart.h"
+#include "task.h"
+#include "heap.h"
+#include "mutex.h"
+
+static os_mutex_t counter_mutex;
+static volatile int shared_counter = 0;
+
+static void uint_to_str(uint32_t value, char *buf) {
+    char tmp[12];
+    int i = 0;
+
+    if (value == 0) {
+        buf[0] = '0';
+        buf[1] = '\0';
+        return;
+    }
+
+    while (value > 0) {
+        tmp[i++] = (char)('0' + (value % 10));
+        value /= 10;
+    }
+
+    int j = 0;
+    while (i > 0) {
+        buf[j++] = tmp[--i];
+    }
+    buf[j] = '\0';
+}
+
+void task1(void) {
+    char num_str[12];
+
+    while (1) {
+        os_mutex_take(&counter_mutex);
+
+        shared_counter++;
+        uart_send_string(USART1_BASE, "Task1: counter = ");
+        uint_to_str((uint32_t)shared_counter, num_str);
+        uart_send_string(USART1_BASE, num_str);
+        uart_send_string(USART1_BASE, "\r\n");
+
+        os_mutex_give(&counter_mutex);
+        os_delay(500);
+    }
+}
+
+void task2(void) {
+    char num_str[12];
+
+    while (1) {
+        os_mutex_take(&counter_mutex);
+
+        shared_counter++;
+        uart_send_string(USART1_BASE, "Task2: counter = ");
+        uint_to_str((uint32_t)shared_counter, num_str);
+        uart_send_string(USART1_BASE, num_str);
+        uart_send_string(USART1_BASE, "\r\n");
+
+        os_mutex_give(&counter_mutex);
+        os_delay(700);
+    }
+}
+
+int main(void) {
+    system_init();
+    systick_init();
+    uart_init(USART1_BASE);
+    os_heap_init();
+
+    os_mutex_init(&counter_mutex);
+
+    os_task_create(task1, 2, 128);
+    os_task_create(task2, 2, 128);
+
+    os_start();
+    return 0;
+}


### PR DESCRIPTION
## Summary
Adds a new sample (`samples/mutex_basic`) demonstrating the use of
`os_mutex_init`, `os_mutex_take`, and `os_mutex_give` for protecting
a shared resource accessed by multiple tasks.

## What it does
- Two tasks (`task1` and `task2`) increment and print a shared
  counter over UART1.
- `task1` runs every 500 ms, `task2` every 700 ms, both at priority 2
  with a stack size of 128.
- A mutex ensures that incrementing the counter and printing its
  value happens atomically, preventing interleaved/corrupted output
  between the two tasks.

## Testing
- Verified the file compiles by temporarily swapping it into
  `app/main.c` and running `make clean && make`.

## Related
Part of #15

---

Signed-off-by: Atharva Manoj Durge <atharvadurge3001@gmail.com>